### PR TITLE
Automated testing around PRs

### DIFF
--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -1,16 +1,15 @@
 trigger:
   - master
-  - hone-automated-testing
 
 pr: none
 
 stages:
-  - stage: 'test'
-    displayName: 'python tests'
+  - stage: 'notebook_tests'
+    displayName: 'notebook tests'
 
     jobs:
-      - job: 'make_notebooks'
-        displayName: 'Make Notebooks'
+      - job: 'imaging_notebook_linux'
+        displayName: 'bragg-edge imaging notebook linux'
         timeoutInMinutes: 30
         pool:
           vmImage: 'ubuntu-18.04'

--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -1,0 +1,34 @@
+trigger:
+  - master
+  - hone-automated-testing
+
+pr: none
+
+stages:
+  - stage: 'test'
+    displayName: 'python tests'
+
+    jobs:
+      - job: 'make_notebooks'
+        displayName: 'Make Notebooks'
+        timeoutInMinutes: 30
+        pool:
+          vmImage: 'ubuntu-18.04'
+        steps:
+          - checkout: self
+            submodules: true
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: 'add conda to PATH'
+          - bash: |
+             set -ex
+             conda config --set always_yes yes --set changeps1 no
+             conda env create -f ess-notebook-latest.yml
+             source activate ess-notebook-latest
+             git clone https://github.com/scipp/ess-notebooks-data.git data
+             python make_config.py ${PWD}/data/ess/v20/imaging
+             mkdir tests
+             cp scippconfig.py tests/
+             find . -not -path "*/\.*" -type f -name "*.ipynb"\
+              | xargs jupyter nbconvert --to python --output-dir tests\
+              --RegexRemovePreprocessor.patterns="['^# exclude-from-export']"
+             find tests -not -path "tests/scippconfig.py" -type f -name "*.py" | xargs python

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -21,8 +21,7 @@ stages:
       - job: 'make_notebooks'
         displayName: 'Make Notebooks'
         timeoutInMinutes: 30
-        pool:
-          vmImage: 'ubuntu-18.04'
+        pool: 'Default'
         steps:
           - checkout: self
             submodules: true

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -40,7 +40,7 @@ stages:
                  conda env create -f ess-notebook.yml
                  source activate ess-notebook
              fi
-             git clone git@github.com:scipp/ess-notebooks-data.git data
+             git clone https://github.com/scipp/ess-notebooks.git data
              python make_config.py ${PWD}/data
              mkdir tests
              cp scippconfig.py tests/

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -20,7 +20,7 @@ stages:
     jobs:
       - job: 'make_notebooks'
         displayName: 'Make Notebooks'
-        timeoutInMinutes: 20
+        timeoutInMinutes: 30
         pool:
           vmImage: 'ubuntu-18.04'
         steps:

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -41,7 +41,7 @@ stages:
                  source activate ess-notebook
              fi
              git clone https://github.com/scipp/ess-notebooks-data.git data
-             python make_config.py ${PWD}/data
+             python make_config.py ${PWD}/data/ess/v20/imaging
              mkdir tests
              cp scippconfig.py tests/
              find . -not -path "*/\.*" -type f -name "*.ipynb"\

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -14,12 +14,12 @@ variables:
   target_branch: $[variables['System.PullRequest.TargetBranch']]
 
 stages:
-  - stage: 'test'
-    displayName: 'python tests'
+  - stage: 'notebook_tests'
+    displayName: 'notebook tests'
 
     jobs:
       - job: 'make_notebooks'
-        displayName: 'Make Notebooks'
+        displayName: 'bragg-edge imaging notebook linux'
         timeoutInMinutes: 30
         pool:
           vmImage: 'ubuntu-18.04'

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -21,7 +21,8 @@ stages:
       - job: 'make_notebooks'
         displayName: 'Make Notebooks'
         timeoutInMinutes: 30
-        pool: 'Default'
+        pool:
+          vmImage: 'ubuntu-18.04'
         steps:
           - checkout: self
             submodules: true

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -40,7 +40,7 @@ stages:
                  conda env create -f ess-notebook.yml
                  source activate ess-notebook
              fi
-             git clone https://github.com/scipp/ess-notebooks.git data
+             git clone https://github.com/scipp/ess-notebooks-data.git data
              python make_config.py ${PWD}/data
              mkdir tests
              cp scippconfig.py tests/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 scippconfig.py
 # Folders
 =======
+data/
+tests/
 .DS_Store
 .ipynb_checkpoints/
 .idea/

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -205,7 +205,7 @@
     "masking_threshold = 0.80\n",
     "\n",
     "# Toggles outputting masked and sliced tiff stacks\n",
-    "output_tiff_stack = True\n",
+    "output_tiff_stack = False\n",
     "\n",
     "# Experiment Metadata\n",
     "measurement_number = 11"

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -247,7 +247,7 @@
     "\n",
     "def load_and_scale(folder_name, scale_factor):\n",
     "    to_load = os.path.join(raw_data_dir, folder_name)\n",
-    "    variable = imaging.tiffs_to_variable(to_load)\n",
+    "    variable = imaging.tiffs_to_variable(to_load, with_variances=False)\n",
     "    variable *= scale_factor\n",
     "    return variable\n",
     "\n",

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -130,8 +130,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geometry = sc.Dataset()\n",
-    "sc.compat.mantid.load_component_info(geometry, instrument_file)"
+    "# geometry = sc.Dataset()\n",
+    "# sc.compat.mantid.load_component_info(geometry, instrument_file)"
    ]
   },
   {

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -603,8 +603,11 @@
    "outputs": [],
    "source": [
     "# Load in IDF for positions of source/sample...etc\n",
+    "print('Loading instrument')\n",
     "sc.compat.mantid.load_component_info(normalized, instrument_file)\n",
-    "wavelength = sc.neutron.convert(normalized, \"tof\", \"wavelength\")"
+    "print('Converting to wavelength')\n",
+    "wavelength = sc.neutron.convert(normalized, \"tof\", \"wavelength\")\n",
+    "print('complete')\n"
    ]
   },
   {

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -71,6 +71,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Floating point precision "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "float_type = np.float32\n",
+    "# Helper to determine scipp dtype from np dtype\n",
+    "def scipp_dtype(dtype):\n",
+    "    return sc.Variable(value=0,dtype=dtype).dtype"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"
@@ -260,7 +280,7 @@
     "\n",
     "def load_and_scale(folder_name, scale_factor):\n",
     "    to_load = os.path.join(raw_data_dir, folder_name)\n",
-    "    variable = imaging.tiffs_to_variable(to_load, dtype=np.float32)\n",
+    "    variable = imaging.tiffs_to_variable(to_load, dtype=float_type)\n",
     "    variable *= scale_factor\n",
     "    return variable\n",
     "\n",
@@ -536,7 +556,7 @@
     "normalized = stitched / reference\n",
     "\n",
     "# Replace special values nan and inf\n",
-    "replacement = sc.Variable(value=0.0, variance=0.0, dtype=sc.dtype.float32)\n",
+    "replacement = sc.Variable(value=0.0, variance=0.0, dtype=float_type)\n",
     "kwargs = {\"nan\": replacement, \"posinf\": replacement, \"neginf\": replacement}\n",
     "for k in normalized.keys():\n",
     "    sc.nan_to_num(normalized[k].data, out=normalized[k].data, **kwargs)"
@@ -721,8 +741,8 @@
     "    data = da / variances\n",
     "    norm = sc.DataArray(data=sc.reciprocal(variances),\n",
     "                        masks=dict(da.masks.items()))\n",
-    "    data.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(sc.dtype.float32))\n",
-    "    norm.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(sc.dtype.float32))\n",
+    "    data.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(scipp_dtype(float_type)))\n",
+    "    norm.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(scipp_dtype(float_type)))\n",
     "    return sc.sum(data, dim) / sc.sum(norm, dim)\n",
     "\n",
     "\n",

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -125,6 +125,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geometry = sc.Dataset()\n",
+    "sc.compat.mantid.load_component_info(geometry, instrument_file)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "pycharm": {
@@ -598,13 +608,13 @@
     "pycharm": {
      "name": "#%% \n"
     },
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
     "# Load in IDF for positions of source/sample...etc\n",
     "print('Loading instrument')\n",
-    "sc.compat.mantid.load_component_info(normalized, instrument_file)\n",
+    "normalized = sc.merge(normalized, geometry)\n",
     "print('Converting to wavelength')\n",
     "wavelength = sc.neutron.convert(normalized, \"tof\", \"wavelength\")\n",
     "print('complete')\n"

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -44,8 +44,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -90,8 +89,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -125,13 +123,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Geometry"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# geometry = sc.Dataset()\n",
-    "# sc.compat.mantid.load_component_info(geometry, instrument_file)"
+    "geometry = sc.Dataset()\n",
+    "sc.compat.mantid.load_component_info(geometry, instrument_file)"
    ]
   },
   {
@@ -152,8 +157,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -240,8 +244,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%% \n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -257,10 +260,9 @@
     "\n",
     "def load_and_scale(folder_name, scale_factor):\n",
     "    to_load = os.path.join(raw_data_dir, folder_name)\n",
-    "    variable = imaging.tiffs_to_variable(to_load)\n",
+    "    variable = imaging.tiffs_to_variable(to_load, dtype=np.float32)\n",
     "    variable *= scale_factor\n",
     "    return variable\n",
-    "\n",
     "\n",
     "ds[\"reference\"] = load_and_scale(folder_name=\"R825-open-beam\",\n",
     "                                 scale_factor=pulse_number_reference)\n",
@@ -288,8 +290,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -326,8 +327,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -409,8 +409,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -446,8 +445,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -507,9 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stitched"
@@ -532,8 +528,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -541,7 +536,7 @@
     "normalized = stitched / reference\n",
     "\n",
     "# Replace special values nan and inf\n",
-    "replacement = sc.Variable(value=0.0, variance=0.0)\n",
+    "replacement = sc.Variable(value=0.0, variance=0.0, dtype=sc.dtype.float32)\n",
     "kwargs = {\"nan\": replacement, \"posinf\": replacement, \"neginf\": replacement}\n",
     "for k in normalized.keys():\n",
     "    sc.nan_to_num(normalized[k].data, out=normalized[k].data, **kwargs)"
@@ -564,8 +559,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -607,8 +601,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%% \n"
-    },
-    "scrolled": false
+    }
    },
    "outputs": [],
    "source": [
@@ -637,8 +630,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": false
+    }
    },
    "outputs": [],
    "source": [
@@ -676,8 +668,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -720,8 +711,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -731,8 +721,8 @@
     "    data = da / variances\n",
     "    norm = sc.DataArray(data=sc.reciprocal(variances),\n",
     "                        masks=dict(da.masks.items()))\n",
-    "    data.masks['zero_error'] = sc.equal(variances, 0.0 * variances.unit)\n",
-    "    norm.masks['zero_error'] = sc.equal(variances, 0.0 * variances.unit)\n",
+    "    data.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(sc.dtype.float32))\n",
+    "    norm.masks['zero_error'] = sc.equal(variances, (0.0 * variances.unit).astype(sc.dtype.float32))\n",
     "    return sc.sum(data, dim) / sc.sum(norm, dim)\n",
     "\n",
     "\n",
@@ -762,8 +752,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -794,8 +783,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -845,8 +833,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -901,8 +888,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": false
+    }
    },
    "outputs": [],
    "source": [
@@ -1041,8 +1027,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": false
+    }
    },
    "outputs": [],
    "source": [
@@ -1123,8 +1108,7 @@
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1326,9 +1310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -257,7 +257,7 @@
     "\n",
     "def load_and_scale(folder_name, scale_factor):\n",
     "    to_load = os.path.join(raw_data_dir, folder_name)\n",
-    "    variable = imaging.tiffs_to_variable(to_load, with_variances=False)\n",
+    "    variable = imaging.tiffs_to_variable(to_load)\n",
     "    variable *= scale_factor\n",
     "    return variable\n",
     "\n",

--- a/ess-notebook-latest.yml
+++ b/ess-notebook-latest.yml
@@ -13,6 +13,3 @@ dependencies:
   - nbformat
   - yapf
   - git
-  - pip
-    - p2j
-


### PR DESCRIPTION
This PR is about getting basic setup and execution of the notebook in place and possible in for bragg-edge imaging.

Noteable features:
* We execute the converted notebook (nbcovnert --to python) not the notebook itself.
  - Can do this now without having docs builds
  - Allow us to ignore (`# exclude-from-export`) cells related to costly plotting
  - Part of a route forward for yapf (though conda has a nb-flake8).
* This branch is coordinated with the `deploy` branch of the `scipp/ess` repository because changes were needed in the supporting imaging scripts. Notably, we make major reductions in memory usage by providing single `float_type` to allow us to execute either float32 or float63. The former gets the whole workflow under the 13GB ram limit on the host azure VMs.
* Data is hosted on auxiliary repo `scipp/ess-notebooks-data`. I have make the directory layout more logical that we had previously on owncloud. In addition, I have removed many files that are not necessary for notebook execution. This gives a reasonably sized repository with sensible clone times. 
* Geometry is loaded first and then merged in with the imaging data after shifting. This is because geometry loading introduces a memory spike (intermediate/temporary) as workspaces are loaded as part of geometry creation.

Lacking:
* The pipleline files are a little rough and duplicate in parts. They will need further clean-up.
* We should have asserts in place for the calculated strain values (though pixel by pixel too complex).