### PR TITLE
Update notebooks for scipp changes

### DIFF
--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -30,8 +30,14 @@ stages:
              find . -not -path "*/\.*" -type f -name "*.ipynb"\
               | xargs jupyter nbconvert --to python --output-dir tests\
               --RegexRemovePreprocessor.patterns="['^# exclude-from-export']"
-             python tests/bragg-edge-imaging-2D.py
-             python tests/sans-reduction.py
+             exclude_list=()
+             for f in tests/*.py; do 
+                 found=0
+                 for g in "${exclude_list[@]}" ; do
+                     [ "$f" = "tests/$g" ] && found=1
+                 done
+                 [ "$found" = 0 ] && python "$f"
+             done
   - stage: 'make_sphinx_documentation'
     displayName: 'make sphinx documentation'
 

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -814,8 +814,7 @@
     "\n",
     "# Average out detector positions\n",
     "positions_dataset = sc.Dataset()\n",
-    "positions_dataset[\"position\"] = sc.Variable(\n",
-    "    rebinned_wavelength.coords[\"position\"])\n",
+    "positions_dataset[\"position\"] = rebinned_wavelength.coords[\"position\"].copy()\n",
     "positions_dataset.coords[\"spectrum_mapping\"] = rebinned_wavelength.coords[\n",
     "    \"spectrum_mapping\"]\n",
     "grouped_positions = sc.groupby(positions_dataset,\n",
@@ -1087,10 +1086,8 @@
     "                plots_counter += 1\n",
     "        im = ax.imshow(strains,\n",
     "                       origin=\"upper\",\n",
-    "                       norm=colors.SymLogNorm(linthresh=5.0e-3),\n",
-    "                       cmap=\"RdBu\",\n",
-    "                       vmin=-5.0e-3,\n",
-    "                       vmax=5.0e-3)\n",
+    "                       norm=colors.SymLogNorm(linthresh=5.0e-3, vmin=-5.0e-3, vmax=5.0e-3, base=np.e),\n",
+    "                       cmap=\"RdBu\")\n",
     "        cb = plt.colorbar(im)\n",
     "        cb.set_label(\"${}$ Lattice strain $\\\\varepsilon$\".format(bragg_edge))\n",
     "        output_filename_list.append(output_filename)\n",
@@ -1115,9 +1112,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "scipp-notebook",
    "language": "python",
-   "name": "python3"
+   "name": "scipp-notebook"
   },
   "language_info": {
    "codemirror_mode": {

--- a/bragg-edge-imaging-2D.ipynb
+++ b/bragg-edge-imaging-2D.ipynb
@@ -1112,9 +1112,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "scipp-notebook",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "scipp-notebook"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/sans-reduction.ipynb
+++ b/sans-reduction.ipynb
@@ -328,7 +328,7 @@
     "    data = sc.neutron.convert(data, 'tof', 'wavelength', out=data)\n",
     "    data = sc.rebin(data, 'wavelength', wavelength_bins)\n",
     "\n",
-    "    monitor = data.coords['monitor1'].value\n",
+    "    monitor = data.meta['monitor1'].value\n",
     "    monitor = background_mean(monitor, 'tof', 40000.0 * sc.units.us,\n",
     "                              99000.0 * sc.units.us)\n",
     "    monitor = sc.neutron.convert(monitor, 'tof', 'wavelength', out=monitor)\n",
@@ -539,9 +539,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "scipp-notebook-build",
    "language": "python",
-   "name": "python3"
+   "name": "scipp-notebook-build"
   },
   "language_info": {
    "codemirror_mode": {
@@ -553,7 +553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/sans-reduction.ipynb
+++ b/sans-reduction.ipynb
@@ -539,9 +539,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "scipp-notebook-build",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "scipp-notebook-build"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Closes #9 
Closes #8 

Fixes for matplotlib warnings and scipp interface changes.
~CI should pass once https://github.com/scipp/scipp/pull/1475 fix is available in scipp-developer package.~

Also execute notebooks in CI according to exclude list rather than include list. This will be needed for the streaming notebooks which cannot be tested in CI.