### PR TITLE
Add upstream project trigger

### DIFF
--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -3,6 +3,13 @@ trigger:
 
 pr: none
 
+resources:
+  pipelines:
+  - pipeline: upstream_ess_master 
+    project: ess
+    source: Master 
+    trigger: true
+
 variables:
   is_release: false
 


### PR DESCRIPTION
Part of https://github.com/scipp/scipp/issues/1494

Successful `ess` project `Master` pipeline will trigger `Master` pipeline in `ess-notebooks` project

Demo of this working using temporary pipeline https://dev.azure.com/scipp/ess-notebooks/_build/results?buildId=3135&view=results

**tester**
Ignore the failing test and look at the link above instead. Failing test is due to the fact I aborted the run after trigger worked.