### PR TITLE
Testing scipy fit for bragg edges

### DIFF
--- a/ess-notebooks-stable.yml
+++ b/ess-notebooks-stable.yml
@@ -19,3 +19,5 @@ dependencies:
   - python
   - psutil
   - pythreejs
+  - scipy
+  - jupyterlab

--- a/imaging/bragg-edge-imaging-2D.ipynb
+++ b/imaging/bragg-edge-imaging-2D.ipynb
@@ -566,6 +566,99 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summed[\"sample\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _erfc(x, x0, a, h):\n",
+    "    return h*special.erfc(-a*(x-x0))\n",
+    "\n",
+    "def _background(x, u, v):\n",
+    "    return u + (x * v)\n",
+    "\n",
+    "def bragg_edge_func(x, u, v, x0, a, h):\n",
+    "    return _erfc(x, x0, a, h) + _background(x, u, v)\n",
+    "\n",
+    "parameters = list(inspect.signature(bragg_edge_func).parameters.keys())[1:]\n",
+    "\n",
+    "def fit_scipy(Bragg_edges_FCC, reference, quiet=False):\n",
+    "    \"\"\"\n",
+    "    Fit a list of Bragg edges using scipy.\n",
+    "    \"\"\"\n",
+    "    x_min_sides = [0.04, 0.05, 0.01, 0.03]\n",
+    "    x_max_sides = [0.04, 0.05, 0.05, 0.07]\n",
+    "    \n",
+    "    fit_list = []\n",
+    "\n",
+    "    h = (sc.max(reference.data) - sc.min(reference.data)).value * 10\n",
+    "    for edge_index in range(Bragg_edges_FCC.shape[0]):\n",
+    "        \n",
+    "        print(edge_index)\n",
+    "        bragg_edge = Bragg_edges_FCC.coords[\"miller-indices\"][\"bragg-edge\",\n",
+    "                                                              edge_index]\n",
+    "        # Initial guess\n",
+    "        xpos_guess = Bragg_edges_FCC[\"bragg-edge\", edge_index].value\n",
+    "        x_min_fit = xpos_guess - xpos_guess * abs(x_min_sides[edge_index])\n",
+    "        x_max_fit = xpos_guess + xpos_guess * abs(x_max_sides[edge_index])\n",
+    "        fit_slice = reference['wavelength', x_min_fit * sc.units.angstrom : x_max_fit * sc.units.angstrom]\n",
+    "        \n",
+    "        guesses = dict(zip(parameters, [1] * len(parameters)))\n",
+    "        guesses['x0'] = xpos_guess\n",
+    "        guesses['h'] = h\n",
+    "        \n",
+    "        if not quiet:\n",
+    "            print(\n",
+    "                \"Now fitting Bragg edge {} at {:.3f} A (between {:.3f} A and {:.3f} A) across image groups\"\n",
+    "                .format(bragg_edge_func, xpos_guess, x_min_fit, x_max_fit))\n",
+    "        \n",
+    "        \n",
+    "        x = (fit_slice.coords['wavelength'].values[-1:] + fit_slice.coords['wavelength'].values[0:-1])/2.0\n",
+    "        #bounds = ([-np.inf, -np.inf, xpos_guess - 0.2 , -np.inf, -np.inf], [np.inf, np.inf, xpos_guess + 0.2 , np.inf, np.inf])\n",
+    "        popt, pcov = curve_fit(bragg_edge_func, x, fit_slice.data.values, p0=list(guesses.values()), absolute_sigma=True)\n",
+    "        params = dict(zip(parameters, popt))\n",
+    "        fit_list.append(params)\n",
+    "\n",
+    "    return fit_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_params2 = fit_scipy(Bragg_edges_FCC, reference=summed[\"sample\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# exclude-from-export\n",
+    "import scipy as sp\n",
+    "fig, ax = plt.subplots()\n",
+    "summed[\"sample\"].plot(ax=ax)\n",
+    "for i, (f_scipy, f_mantid) in enumerate(zip(fit_params2, fit_params)):\n",
+    "    x = np.linspace(f_scipy['x0'] - 0.3, f_scipy['x0'] + 0.3, 100)\n",
+    "    print(f'abs center difference in Angstrom for edge {i}', sc.abs(f_scipy['x0'] - f_mantid['f1.x0']).value)\n",
+    "    y = bragg_edge_func(x, **f_scipy)\n",
+    "    ax.plot(x, y, color=\"C{}\".format(i+1), label=Bragg_edges_FCC.coords['miller-indices'].values[i])\n",
+    "ax.legend()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Investigation as part of #45 

This was not entirely successful:

I managed to get `curve_fit` to perform for the unstrained sample case, but it performed poorly for the elastic cases (pixel group by pixel group). This is likely because.
1. Pixel by pixel we have fewer statistics
2. We have highly tuned parameters to get `curve_fit` to work for the un-strained case (at all), these are likely not working at all for the elastic case.

Ultimately this is not on the critical path. Toflib is the desired analysis tool here. It would probably be better to attempt to import and use Toflib directly for the fitting. https://neutronimaging.github.io/ToFImaging/UserManual-EdgeFitting.html https://github.com/neutronimaging/ToFImaging/blob/master/src/tofimaging/EdgeFitting.py as part of a separate exercise. Note that Toflib uses scipy curve_fit under the hood.